### PR TITLE
Implement role selection for sign-up forms

### DIFF
--- a/src/app/account/auth/register2/register2.component.html
+++ b/src/app/account/auth/register2/register2.component.html
@@ -125,6 +125,18 @@
                                         </div>
                                     </div>
 
+                                    <div class="mb-3">
+                                        <label for="role">Role</label>
+                                        <select formControlName="roleId" class="form-control" id="role"
+                                                [ngClass]="{ 'is-invalid': submitted && f.roleId.errors }">
+                                            <option value="">Select role</option>
+                                            <option *ngFor="let role of roles" [value]="role.id">{{ role.name }}</option>
+                                        </select>
+                                        <div *ngIf="submitted && f.roleId.errors" class="invalid-feedback">
+                                            <div *ngIf="f.roleId.errors.required">Role is required</div>
+                                        </div>
+                                    </div>
+
                                     <div>
                                         <p class="mb-0">By registering you agree to the Skote <a
                                                 href="javascript: void(0);" class="text-primary">Terms of Use</a>

--- a/src/app/account/auth/register2/register2.component.ts
+++ b/src/app/account/auth/register2/register2.component.ts
@@ -7,6 +7,7 @@ import { AuthenticationService } from '../../../core/services/auth.service';
 import { environment } from '../../../../environments/environment';
 import { first } from 'rxjs/operators';
 import { UserProfileService } from '../../../core/services/user.service';
+import { RoleService } from '../../../pages/system/role/role.service';
 
 @Component({
   selector: 'app-register2',
@@ -19,9 +20,16 @@ export class Register2Component implements OnInit {
   submitted:any = false;
   error:any = '';
   successmsg:any = false;
+  roles: any[] = [];
 
-  constructor(private formBuilder: UntypedFormBuilder, private route: ActivatedRoute, private router: Router, private authenticationService: AuthenticationService,
-    private userService: UserProfileService) { }
+  constructor(
+    private formBuilder: UntypedFormBuilder,
+    private route: ActivatedRoute,
+    private router: Router,
+    private authenticationService: AuthenticationService,
+    private userService: UserProfileService,
+    private roleService: RoleService
+  ) { }
   // set the currenr year
   year: number = new Date().getFullYear();
 
@@ -30,7 +38,9 @@ export class Register2Component implements OnInit {
       username: ['', Validators.required],
       email: ['', [Validators.required, Validators.email]],
       password: ['', Validators.required],
+      roleId: ['', Validators.required],
     });
+    this.roleService.getAllRoles().subscribe(roles => this.roles = roles);
   }
 
   // convenience getter for easy access to form fields

--- a/src/app/account/auth/signup/signup.component.html
+++ b/src/app/account/auth/signup/signup.component.html
@@ -71,6 +71,18 @@
                   </div>
                 </div>
 
+                <div class="mb-3">
+                  <label for="role" class="form-label">Role</label>
+                  <select formControlName="roleId" class="form-control" id="role"
+                          [ngClass]="{ 'is-invalid': submitted && f.roleId.errors }">
+                    <option value="">Select role</option>
+                    <option *ngFor="let role of roles" [value]="role.id">{{ role.name }}</option>
+                  </select>
+                  <div *ngIf="submitted && f.roleId.errors" class="invalid-feedback">
+                    <div *ngIf="f.roleId.errors.required">Role is required</div>
+                  </div>
+                </div>
+
                 <div class="mt-4 d-grid">
                   <button class="btn btn-primary" type="submit">Register</button>
                 </div>

--- a/src/app/account/auth/signup/signup.component.ts
+++ b/src/app/account/auth/signup/signup.component.ts
@@ -6,6 +6,7 @@ import { AuthenticationService } from '../../../core/services/auth.service';
 import { environment } from '../../../../environments/environment';
 import { first } from 'rxjs/operators';
 import { UserProfileService } from '../../../core/services/user.service';
+import { RoleService } from '../../../pages/system/role/role.service';
 
 @Component({
   selector: 'app-signup',
@@ -18,20 +19,30 @@ export class SignupComponent implements OnInit {
   submitted:any = false;
   error:any = '';
   successmsg:any = false;
+  roles: any[] = [];
 
   // set the currenr year
   year: number = new Date().getFullYear();
 
   // tslint:disable-next-line: max-line-length
-  constructor(private formBuilder: UntypedFormBuilder, private route: ActivatedRoute, private router: Router, private authenticationService: AuthenticationService,
-    private userService: UserProfileService) { }
+  constructor(
+    private formBuilder: UntypedFormBuilder,
+    private route: ActivatedRoute,
+    private router: Router,
+    private authenticationService: AuthenticationService,
+    private userService: UserProfileService,
+    private roleService: RoleService
+  ) { }
 
   ngOnInit() {
     this.signupForm = this.formBuilder.group({
       username: ['', Validators.required],
       email: ['', [Validators.required, Validators.email]],
       password: ['', Validators.required],
+      roleId: ['', Validators.required],
     });
+
+    this.roleService.getAllRoles().subscribe(roles => this.roles = roles);
   }
 
   // convenience getter for easy access to form fields

--- a/src/app/core/models/auth.models.ts
+++ b/src/app/core/models/auth.models.ts
@@ -6,4 +6,5 @@ export class User {
     lastName?: string;
     token?: string;
     email: string;
+    roleId?: string;
 }

--- a/src/app/pages/system/role/role.component.ts
+++ b/src/app/pages/system/role/role.component.ts
@@ -98,8 +98,24 @@ export class RoleComponent implements OnInit {
   }
 
   openDetailModal(template: TemplateRef<any>, item: any): void {
-    this.selectedItem = item;
-    this.modalRef = this.modalService.show(template, { class: 'modal-lg' });
+    const code = item?.code;
+    if (!code) {
+      this.toastService.error('Không tìm thấy mã vai trò!');
+      this.selectedItem = item;
+      this.modalRef = this.modalService.show(template, { class: 'modal-lg' });
+      return;
+    }
+    this.roleService.getRoleDetail(code).subscribe({
+      next: (res) => {
+        this.selectedItem = res?.data || item;
+        this.modalRef = this.modalService.show(template, { class: 'modal-lg' });
+      },
+      error: () => {
+        this.toastService.error('Không thể lấy thông tin chi tiết vai trò!');
+        this.selectedItem = item;
+        this.modalRef = this.modalService.show(template, { class: 'modal-lg' });
+      }
+    });
   }
 
   openCreateModal(): void {
@@ -139,9 +155,9 @@ export class RoleComponent implements OnInit {
   }
 
   approveRole(): void {
-    const id = this.selectedItem?.id;
-    if (!id) return;
-    this.roleService.approveRole(id).subscribe({
+    const code = this.selectedItem?.code;
+    if (!code) return;
+    this.roleService.approveRole(code).subscribe({
       next: () => {
         this.toastService.success('Phê duyệt yêu cầu thành công!');
         this.modalRef?.hide();
@@ -163,9 +179,9 @@ export class RoleComponent implements OnInit {
   confirmRejectRole(): void {
     this.submittedReject = true;
     if (this.rejectForm.invalid) return;
-    const id = this.selectedItem?.id;
-    if (!id) return;
-    this.roleService.rejectRole(id, this.rejectForm.value.reason).subscribe({
+    const code = this.selectedItem?.code;
+    if (!code) return;
+    this.roleService.rejectRole(code, this.rejectForm.value.reason).subscribe({
       next: () => {
         this.toastService.success('Đã từ chối yêu cầu thành công!');
         this.modalRef?.hide();
@@ -195,7 +211,7 @@ export class RoleComponent implements OnInit {
       name: this.roleForm.value.name,
       description: this.roleForm.value.description,
     };
-    this.roleService.updateRole(this.selectedItem.id, payload).subscribe({
+    this.roleService.updateRole(this.selectedItem.code, payload).subscribe({
       next: () => {
         this.toastService.success('Cập nhật vai trò thành công!');
         this.modalRef?.hide();
@@ -213,8 +229,8 @@ export class RoleComponent implements OnInit {
   }
 
   confirmDeleteRole(): void {
-    if (!this.selectedItem?.id) return;
-    this.roleService.deleteRole(this.selectedItem.id).subscribe({
+    if (!this.selectedItem?.code) return;
+    this.roleService.deleteRole(this.selectedItem.code).subscribe({
       next: () => {
         this.toastService.success('Đã gửi yêu cầu xóa thành công!');
         this.modalRef?.hide();

--- a/src/app/pages/system/role/role.service.ts
+++ b/src/app/pages/system/role/role.service.ts
@@ -1,6 +1,7 @@
 import { Injectable } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
 import { Observable } from 'rxjs';
+import { map } from 'rxjs/operators';
 
 @Injectable({ providedIn: 'root' })
 export class RoleService {
@@ -10,6 +11,12 @@ export class RoleService {
 
   getRoles(params: any): Observable<any> {
     return this.http.get<any>(this.apiUrl, { params });
+  }
+
+  getAllRoles(): Observable<any[]> {
+    return this.http.get<any>(this.apiUrl, {
+      params: { pageIndex: 1, pageSize: 1000 }
+    }).pipe(map(res => res?.data?.items ?? []));
   }
 
   createRole(data: any): Observable<any> {

--- a/src/app/pages/system/role/role.service.ts
+++ b/src/app/pages/system/role/role.service.ts
@@ -9,8 +9,13 @@ export class RoleService {
 
   constructor(private http: HttpClient) {}
 
+
   getRoles(params: any): Observable<any> {
     return this.http.get<any>(this.apiUrl, { params });
+  }
+
+  getRoleDetail(code: string): Observable<any> {
+    return this.http.get<any>(`${this.apiUrl}/${code}`);
   }
 
   getAllRoles(): Observable<any[]> {
@@ -23,19 +28,19 @@ export class RoleService {
     return this.http.post<any>(this.apiUrl, data);
   }
 
-  updateRole(id: string, data: any): Observable<any> {
-    return this.http.put<any>(`${this.apiUrl}/${id}`, data);
+  updateRole(code: string, data: any): Observable<any> {
+    return this.http.put<any>(`${this.apiUrl}/${code}`, data);
   }
 
-  deleteRole(id: string): Observable<any> {
-    return this.http.delete<any>(`${this.apiUrl}/${id}`);
+  deleteRole(code: string): Observable<any> {
+    return this.http.delete<any>(`${this.apiUrl}/${code}`);
   }
 
-  approveRole(id: string): Observable<any> {
-    return this.http.post<any>(`${this.apiUrl}/${id}/approve`, {});
+  approveRole(code: string): Observable<any> {
+    return this.http.post<any>(`${this.apiUrl}/${code}/approve`, {});
   }
 
-  rejectRole(id: string, reason: string): Observable<any> {
-    return this.http.post<any>(`${this.apiUrl}/${id}/reject`, { reason });
+  rejectRole(code: string, reason: string): Observable<any> {
+    return this.http.post<any>(`${this.apiUrl}/${code}/reject`, { reason });
   }
 }


### PR DESCRIPTION
## Summary
- add `roleId` to `User` model
- expose `getAllRoles` in `RoleService`
- inject `RoleService` in sign-up components and load roles on init
- include role dropdown in both sign-up forms

## Testing
- `npm install --silent`
- `npx ng test --watch=false --browsers=ChromeHeadless` *(fails: No binary for ChromeHeadless)*

------
https://chatgpt.com/codex/tasks/task_e_686412a4c5ac8328a668329adb4c62bf